### PR TITLE
add Brainyduck

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@ Curated list of Fauna resources that live outside of the fauna.com or docs.fauna
 ## :bookmark_tabs: Contents
 
 - [Tools](#tools)
+	- [Development lifecycle](#development-lifecycle)
 	- [Wrappers & libraries](#wrappers-and-libraries)
 		- [JavaScript](#javascript)
 		- [Python](#python)
@@ -40,6 +41,9 @@ Curated list of Fauna resources that live outside of the fauna.com or docs.fauna
 
 
 ## Tools
+
+### Development lifecycle
+* [Brainyduck](https://duck.brainy.sh) - Quickly build powerful backends using only your graphql schemas. Build SDKs, deploy schemas, UDFs, roles and indexes.
 
 ### Wrappers and libraries
 #### JavaScript


### PR DESCRIPTION
It took me more than 2 years in the making (and I had to quit my job before I could finally finish it 😅) but I am finally proud to announce that the [Brainyduck](https://duck.brainy.sh) project (formerly Faugra) is ready for its launch!

I have created a new category for it here because it doesn't match the goals of any of the other tools listed. Brainyduck is a tool that stays with the developer throughout the whole development process, from building the first schema until the deployments to production.

I am not sure I chose the best category name, but it definitely needs a new category regardless.